### PR TITLE
fix: change arch detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/dex4er/asdf-vals/actions/workflows/ci.yml/badge.svg)](https://github.com/dex4er/asdf-vals/actions/workflows/ci.yml)
 
-[vals](https://github.com/variantdev/vals) plugin for the [asdf](https://github.com/asdf-vm/asdf) version manager.
+[vals](https://github.com/helmfile/vals) plugin for the [asdf](https://github.com/asdf-vm/asdf) version manager.
 
 ## Install
 

--- a/bin/install
+++ b/bin/install
@@ -19,15 +19,15 @@ install() {
 	platform=$(uname | tr '[:upper:]' '[:lower:]')
 
 	local arch
-	case "$(uname -m)" in
+	case "$(arch)" in
 	i386 | i686 | x86) arch="386" ;;
 	x86_64) arch="amd64" ;;
 	aarch64) arch="arm64" ;;
-	*) arch="$(uname -m)" ;;
+	*) arch="$(arch)" ;;
 	esac
 
 	local download_url
-	download_url="https://github.com/variantdev/vals/releases/download/v${version}/vals_${version}_${platform}_${arch}.tar.gz"
+	download_url="https://github.com/helmfile/vals/releases/download/v${version}/vals_${version}_${platform}_${arch}.tar.gz"
 
 	mkdir -p "${bin_install_path}"
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-releases_path=https://api.github.com/repos/variantdev/vals/releases
+releases_path=https://api.github.com/repos/helmfile/vals/releases
 cmd="curl -s"
 if [[ -n ${GITHUB_API_TOKEN} ]]; then
 	cmd="${cmd} -H 'Authorization: token ${GITHUB_API_TOKEN}'"


### PR DESCRIPTION
Since uname -m doesn't show the correct arch on Apple Silicon 

```
uname -m
x86_64

arch
arm64
```

I'm using zsh in iTerm2 without Rosetta enable.

```
which zsh
/opt/homebrew/bin/zsh

uname -m
x86_64

file /opt/homebrew/bin/zsh
/opt/homebrew/bin/zsh: Mach-O 64-bit executable arm64
```